### PR TITLE
Add ability to specify a source IP address for connections.

### DIFF
--- a/lib/simple-graphite.rb
+++ b/lib/simple-graphite.rb
@@ -3,17 +3,18 @@ require 'socket'
 
 class Graphite
 
-  attr_accessor :host, :port, :time
+  attr_accessor :host, :port, :time, :source
 
   def initialize(options = {})
-    @host = options[:host]
-    @port = options[:port] || 2003
+    @host   = options[:host]
+    @port   = options[:port] || 2003
+    @source = options[:source] || nil
     @time = Time.now.to_i
   end
 
   def push_to_graphite
     raise "You need to provide both the hostname and the port" if @host.nil? || @port.nil?
-    socket = TCPSocket.new(@host, @port)
+    socket = TCPSocket.new(@host, @port, @source)
     yield socket
     socket.close
   end


### PR DESCRIPTION
Useful, if as in my case, you're graphite-ing from a firewall, and need to
specify a source IP. Defaults to nil, which is what the define
defaults to. No tests yet.
