### PR TITLE
Add UDP support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,3 @@
+2013-05-12 Ryan McKern <ryan@orangefort.com>
+  * Added support for UDP and TCP connections to Graphite
+  * Added tests to validate support for UDP and TCP connections

--- a/lib/graphite/socket.rb
+++ b/lib/graphite/socket.rb
@@ -1,0 +1,38 @@
+require 'socket'
+
+class Graphite
+  class Socket
+    attr_accessor :host, :port, :type, :socket
+
+    def initialize(host, port, socket_type)
+      @host = host
+      @port = port
+      @type = socket_type
+      @socket = nil
+    end
+
+    def puts(event)
+      begin
+        connect unless @socket
+        @socket.write("#{event}")
+      ensure
+        close
+      end
+    end
+
+    def close
+      @socket && @socket.close
+    rescue => e
+      warn "#{self.class} - #{e.class} - #{e.message}"
+    end
+
+    def connect
+      @socket = case @type
+      when :udp then UDPSocket.new.tap {|s| s.connect(@host, @port)}
+      when :tcp then TCPSocket.new(@host, @port)
+      else
+        raise NameError, "#{@type} is invalid; must be udp or tcp"
+      end
+    end
+  end
+end

--- a/lib/simple-graphite.rb
+++ b/lib/simple-graphite.rb
@@ -1,19 +1,20 @@
 require 'socket'
-
+require 'graphite/socket'
 
 class Graphite
 
-  attr_accessor :host, :port, :time
+  attr_accessor :host, :type, :port, :time
 
   def initialize(options = {})
     @host = options[:host]
-    @port = options[:port] || 2003
+    @type = options[:type] ||= :tcp
+    @port = options[:port] ||= @type.eql?(:tcp) ? 2003 : 8125
     @time = Time.now.to_i
   end
 
   def push_to_graphite
-    raise "You need to provide both the hostname and the port" if @host.nil? || @port.nil?
-    socket = TCPSocket.new(@host, @port)
+    raise "You need to provide a hostname" if @host.nil?
+    socket = Graphite::Socket.new @host, @port, @type
     yield socket
     socket.close
   end
@@ -27,7 +28,7 @@ class Graphite
   end
 
   def hostname
-    Socket.gethostname
+    ::Socket.gethostname
   end
 
   def self.time_now

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,15 @@ RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
+  config.color_enabled = true
+  config.tty = true
+  config.formatter = :documentation # :progress, :html, :textmate
 end
 
 TCP_NEW = TCPSocket.method(:new) unless defined? TCP_NEW
+UDP_NEW = UDPSocket.method(:new) unless defined? UDP_NEW
 
-class FakeTCPSocket
+class FakeSockets
   attr :buffer, true
 
   def initialize
@@ -33,19 +37,37 @@ class FakeTCPSocket
 
   def close
   end
-  
+
   def puts(some_text)
     @buffer += some_text
   end
 
 end
 
-def mock_tcp()
+class FakeTCPSocket < FakeSockets
+end
+
+class FakeUDPSocket < FakeSockets
+  def connect(host, port)
+  end
+end
+
+def mock_tcp
   ftcp = FakeTCPSocket.new
   TCPSocket.stub!(:new).and_return { ftcp }
   ftcp
 end
 
 def unmock_tcp
-  TCKSocket.stub!(:new).and_return {TCP_NEW.call}
+  TCPSocket.stub!(:new).and_return {TCP_NEW.call}
+end
+
+def mock_udp
+  fudp = FakeUDPSocket.new
+  UDPSocket.stub!(:new).and_return { fudp }
+  fudp
+end
+
+def unmock_udp
+  UDPSocket.stub!(:new).and_return {UDP_NEW.call}
 end


### PR DESCRIPTION
I had a need to send metrics to Graphite (not StatsD), so I extended simple-graphite to include UDP support. The new features should be drop-in and backwards compatable.

This included creating a new subclass (<tt>Graphite::Socket</tt>) to support the differences in connecting to <tt>TCPSocket</tt> vs. <tt>UDPSocket</tt>, as well as defining default port configurations for each protocol. I also updated the Rspec tests to understand UDP mocks and UDP operations. While I was in there, I reworded test names a little; if that's a problem, mea culpa.

The work in Graphite::Socket is based in part on work from the MIT licensed gem
"logstash-logger", by David Butler.
