### PR TITLE
Use Simplecov, Gem::PackageTask, and RSpec in Rakefile

### DIFF
--- a/spec/simple-graphite_spec.rb
+++ b/spec/simple-graphite_spec.rb
@@ -40,4 +40,9 @@ describe Graphite do
     ftcp.buffer.should == "foo.bar 200 #{time}\nfoo.test 10.2 #{time}\n"
   end
 
+  it "returns a valid hostname" do
+    a = Graphite.new
+    a.hostname.should == Socket.gethostname
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+if ENV["COVERAGE"]
+  require 'simplecov'
+  SimpleCov.start
+end
+
 require 'socket'
 
 RSpec.configure do |config|
@@ -33,7 +38,7 @@ class FakeTCPSocket
 
   def close
   end
-  
+
   def puts(some_text)
     @buffer += some_text
   end


### PR DESCRIPTION
This is a separate branch from my other PR for UDP support. spicycode-rcov seems to  be unmaintained (<tt>gem</tt> doesn't even know what it is any more) and [Rcov](https://github.com/relevance/rcov) doesn't work in Ruby 1.9, so I've migrated to SimpleCov.

Jeweler support has been replaced with by using a new :gemspec task
to generate <tt>simple-graphite.gemspec</tt> and by using Gem::PackageTask for
building new gem files.

The <tt>:test</tt> functions have been removed and replaced with
Rspec tasks.

A test for hostname validation has been added. This brings coverage
up to 100% on the v1.1.1 codebase. 
