### PR TITLE
The UDP merge broke a lot of stuff

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simple-graphite (1.1.1)
+    simple-graphite (2.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/simple-graphite.rb
+++ b/lib/simple-graphite.rb
@@ -14,9 +14,12 @@ class Graphite
 
   def push_to_graphite
     raise "You need to provide a hostname" if @host.nil?
-    socket = Graphite::Socket.new @host, @port, @type
-    yield socket
-    socket.close
+    begin
+      socket = Graphite::Socket.new @host, @port, @type
+      yield socket
+    ensure
+      socket.close
+    end
   end
 
   def send_metrics(metrics_hash)


### PR DESCRIPTION
Part of this commit might be controversial because I've replaced the mocked
Sockets with actual sockets.  The reason is that mocking them out properly
would require quite a lot of work, and a comprehensive knowledge of what's
valid for the various socket types.

Assuming that is accepted, the UDP merge broke the `push_to_graphite` method. 
Also, because UDP is datagram-based, not connection-based, you can't just
submit multiple messages over a single connection - you either need to open
and close the socket for every message, or roll a sequence of messages up into
a single datagram, but then you run the risk of hitting size limits.  However,
for TCP we obviously want to keep the reduced overhead of multiple messages
over a single connection.

I've tried to account for all of these issues with this commit.
